### PR TITLE
Added semi-colons to Disribution Statements

### DIFF
--- a/cyber.dtx
+++ b/cyber.dtx
@@ -949,14 +949,14 @@
 %    \begin{macrocode}
 \def\distributionB#1#2{%
     \gdef\@distribution{%
-        \textbf{DISTRIBUTION STATEMENT B}: Distribution authorized to U.S. Government agencies only #1 \@date. Other requests for this document shall be referred to #2.}}
+        \textbf{DISTRIBUTION STATEMENT B}: Distribution authorized to U.S. Government agencies only; #1; \@date. Other requests for this document shall be referred to #2.}}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\distributionC}
 %    \begin{macrocode}
 \def\distributionC#1#2{%
     \gdef\@distribution{%
-        \textbf{DISTRIBUTION STATEMENT C}: Distribution authorized to U.S. Government agencies and their contractors #1 \@date. Other requests for this document shall be referred to #2.}}
+        \textbf{DISTRIBUTION STATEMENT C}: Distribution authorized to U.S. Government agencies and their contractors; #1; \@date. Other requests for this document shall be referred to #2.}}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\distributionD}
@@ -966,14 +966,14 @@
 %    \begin{macrocode}
 \def\distributionD#1#2{%
     \gdef\@distribution{%
-        \textbf{DISTRIBUTION STATEMENT D}: Distribution authorized to the Department of Defense and U.S. DoD contractors only #1 \@date. Other requests shall be referred to #2.}}
+        \textbf{DISTRIBUTION STATEMENT D}: Distribution authorized to the Department of Defense and U.S. DoD contractors only; #1; \@date. Other requests shall be referred to #2.}}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\distributionE}
 %    \begin{macrocode}
 \def\distributionE#1#2{%
     \gdef\@distribution{%
-        \textbf{DISTRIBUTION STATEMENT E}: Distribution authorized to DoD Components only #1 \@date. Other requests shall be referred to #2.}}
+        \textbf{DISTRIBUTION STATEMENT E}: Distribution authorized to DoD Components only; #1; \@date. Other requests shall be referred to #2.}}
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\distributionF}


### PR DESCRIPTION
Changed Disribution Statement formatting slightly to include semi-colons as shown in http://www.dtic.mil/dtic/tr/fulltext/u2/a369766.pdf

Some newer memos provide mixed guidance on the use of semi-colons. http://www.dtic.mil/dtic/pdf/distribution_statements_and_reasons.pdf omits semi-colons on Page 1, but includes them on Page 2.